### PR TITLE
Fix recursive search bug and define Tag struct

### DIFF
--- a/HTMLValidator.cpp
+++ b/HTMLValidator.cpp
@@ -266,7 +266,7 @@ bool html_is_valid(const std::string &document) {
 
 Tag *getElementByID(Tag *const root, const std::string &id) {
 
-    if (id == "") {
+    if (root == nullptr || id.empty()) {
         return nullptr;
     }
 
@@ -275,10 +275,10 @@ Tag *getElementByID(Tag *const root, const std::string &id) {
     }
 
     for (Tag *each : root->_children) {
-        if (getElementByID(each, id) != nullptr) {
-            return getElementByID(each, id);
+        Tag *result = getElementByID(each, id);
+        if (result != nullptr) {
+            return result;
         }
-        getElementByID(each, id);
     }
 
     return nullptr;

--- a/README.txt
+++ b/README.txt
@@ -40,4 +40,3 @@ All whitespace in a document is treated as a space (i.e., the character ' ').
 All whitespace is omitted between the '>' symbol at the end of a tag (open or close), and the start of the next tag or content text.  
 All strings of consecutive whitespace are treated as a single space. This happens both within a tag and within the content (e.g., 4 spaces to indent code in a document would be displayed as a single space on a page). 
 In the descriptions above, text means any string (including the empty string, unless specified otherwise). Any number includes 0. 
-1

--- a/Tag.hpp
+++ b/Tag.hpp
@@ -1,0 +1,13 @@
+#ifndef TAG_HPP
+#define TAG_HPP
+
+#include <string>
+#include <list>
+
+struct Tag {
+    std::string _name;
+    std::string _id;
+    std::list<Tag*> _children;
+};
+
+#endif // TAG_HPP


### PR DESCRIPTION
## Summary
- define a minimal `Tag` struct in a new `Tag.hpp`
- fix recursion logic in `getElementByID`
- clean up trailing content in `README.txt`

## Testing
- `g++ -std=c++11 -c HTMLValidator.cpp`
- `g++ -std=c++11 main.cpp -o validator`
- `./validator sample-pages/valid-hello.html`
- `./validator sample-pages/invalid-body-before-head.html`
- `./validator sample-pages/invalid-br-in-head.html`
- `./validator sample-pages/valid-lots-of-spaces.html`

------
https://chatgpt.com/codex/tasks/task_e_683f9fae8f34832c98180601354167a4