### PR TITLE
Fix warnings due to signed/unsigned comparisons

### DIFF
--- a/HTMLValidator.cpp
+++ b/HTMLValidator.cpp
@@ -6,12 +6,13 @@
 #include <stack>
 #include <queue>
 #include <sstream>
+#include <cstddef>
 
 std::string lower(std::string str);
 
-int it;
+std::size_t it;
 
-int advanceitToNextChar(std::string str);
+std::size_t advanceitToNextChar(const std::string &str);
 
 bool properEndTag(std::string document);
 
@@ -286,13 +287,13 @@ Tag *getElementByID(Tag *const root, const std::string &id) {
 
 
 std::string lower(std::string str) {
-    for (int i = 0; i < str.size(); ++i) {
+    for (std::size_t i = 0; i < str.size(); ++i) {
         str.at(i) = tolower(str.at(i));
     }
     return str;
 }
 
-int advanceitToNextChar(std::string str) {
+std::size_t advanceitToNextChar(const std::string &str) {
     while (isspace(str.at(it))) {
         ++it;
     }


### PR DESCRIPTION
## Summary
- resolve compiler warnings by switching global iterator and helper to `size_t`
- adjust prototype and implementation of `advanceitToNextChar`
- use `size_t` loop variable in `lower`

## Testing
- `g++ -Wall -Wextra -std=c++17 main.cpp HTMLValidator.cpp -o html_validator`
- `./html_validator sample-pages/valid-hello.html`
- `./html_validator sample-pages/invalid-no-doctype.html`


------
https://chatgpt.com/codex/tasks/task_e_683fa4bdf964832c9fce699b9ea5b1ce