### PR TITLE
Modernize HTMLValidator with C++23

### DIFF
--- a/Tag.hpp
+++ b/Tag.hpp
@@ -1,13 +1,14 @@
 #ifndef TAG_HPP
 #define TAG_HPP
 
+#include <memory>
 #include <string>
-#include <list>
+#include <vector>
 
 struct Tag {
     std::string _name;
     std::string _id;
-    std::list<Tag*> _children;
+    std::vector<std::unique_ptr<Tag>> _children;
 };
 
 #endif // TAG_HPP


### PR DESCRIPTION
## Summary
- replace list of raw pointers with vector of unique_ptr in `Tag`
- switch to string_view parameters and add [[nodiscard]] attributes
- modernize includes, algorithms, and whitespace handling
- remove unused headers and use range-based loops

## Testing
- `g++ -std=c++23 -Wall -Wextra -pedantic -g main.cpp HTMLValidator.cpp -o validator`
- `./validator sample-pages/valid-hello.html`
- `./validator sample-pages/invalid-body-before-head.html`


------
https://chatgpt.com/codex/tasks/task_e_683fa626caf4832c98d82c3c7c4a232c