### PR TITLE
Optimize HTML validator

### DIFF
--- a/HTMLValidator.cpp
+++ b/HTMLValidator.cpp
@@ -5,14 +5,12 @@
 #include <cctype>
 #include <cstddef>
 #include <memory>
-#include <ranges>
-#include <sstream>
 #include <string_view>
 #include <vector>
 
 namespace {
 
-[[nodiscard]] std::string lower(std::string str);
+[[nodiscard]] bool iequals(std::string_view a, std::string_view b);
 
 void advanceToNextChar(std::string_view str, std::size_t &pos);
 
@@ -37,228 +35,214 @@ void advanceToNextChar(std::string_view str, std::size_t &pos);
         return false;
     }
     std::size_t pos = 0;
+    std::string_view doc(document);
 
-
-    advanceToNextChar(document, pos);
+    advanceToNextChar(doc, pos);
 
     if (document.size() < pos + 15) {
         return false;
     }
 
-    std::string docType(document.substr(pos, 9)); //<!doctype
-    docType = lower(docType);
+    std::string_view docType = doc.substr(pos, 9); //<!doctype
 
-    if (docType.compare("<!doctype") != 0) {
+    if (!iequals(docType, "<!doctype")) {
         return false;
     }
     pos += 9;
-    advanceToNextChar(document, pos);
+    advanceToNextChar(doc, pos);
 
-    std::string h(document.substr(pos, 4)); //html
-    h = lower(h);
+    std::string_view h = doc.substr(pos, 4); //html
 
-    if (h.compare("html") != 0) {
+    if (!iequals(h, "html")) {
         return false;
     }
     pos += 4;
 
-    if (!properEndTag(document, pos)) {
+    if (!properEndTag(doc, pos)) {
         return false;
     }
 
     pos += 1;
-    advanceToNextChar(document, pos);
+    advanceToNextChar(doc, pos);
 
-    std::string html(document.substr(pos, 5)); //<html
-    html = lower(html);
+    std::string_view html = doc.substr(pos, 5); //<html
 
-    if (html.compare("<html") != 0) {
+    if (!iequals(html, "<html")) {
         return false;
     }
     pos += 5;
-    advanceToNextChar(document, pos);
-    if (document.substr(pos, 2).compare("id") == 0) {
-        if (!validID(document, pos)) {
+    advanceToNextChar(doc, pos);
+    if (doc.substr(pos, 2).compare("id") == 0) {
+        if (!validID(doc, pos)) {
             return false;
         }
     }
 
-    if (!properEndTag(document, pos)) {
+    if (!properEndTag(doc, pos)) {
         return false;
     }
     pos += 1;
-    advanceToNextChar(document, pos);
+    advanceToNextChar(doc, pos);
 
-    std::string head(document.substr(pos, 5)); //<head
-    head = lower(head);
+    std::string_view head = doc.substr(pos, 5); //<head
 
-    if (head.compare("<head") != 0) {
+    if (!iequals(head, "<head")) {
         return false;
     }
     pos += 5;
-    advanceToNextChar(document, pos);
-    if (document.substr(pos, 2).compare("id") == 0) {
-        if (!validID(document, pos)) {
+    advanceToNextChar(doc, pos);
+    if (doc.substr(pos, 2).compare("id") == 0) {
+        if (!validID(doc, pos)) {
             return false;
         }
     }
-    if (!properEndTag(document, pos)) {
+    if (!properEndTag(doc, pos)) {
         return false;
     }
     pos += 1;  // it is now right after '<head>'
-    advanceToNextChar(document, pos);
+    advanceToNextChar(doc, pos);
 
-    std::string title(document.substr(pos, 6)); //<title
-    title = lower(title);
+    std::string_view title = doc.substr(pos, 6); //<title
 
-    if (title.compare("<title") != 0) {
+    if (!iequals(title, "<title")) {
         return false;
     }
     pos += 6;
-    advanceToNextChar(document, pos);
-    if (document.substr(pos, 2).compare("id") == 0) {
-        if (!validID(document, pos)) {
+    advanceToNextChar(doc, pos);
+    if (doc.substr(pos, 2).compare("id") == 0) {
+        if (!validID(doc, pos)) {
             return false;
         }
     }
 
-    if (!properEndTag(document, pos)) {
+    if (!properEndTag(doc, pos)) {
         return false;
     }
     pos += 1; //it now right after <title>
-    advanceToNextChar(document, pos);
+    advanceToNextChar(doc, pos);
 
-    std::string cTitle(document.substr(pos, 7));
-    cTitle = lower(cTitle);
+    std::string_view cTitle = doc.substr(pos, 7);
 
-    if (cTitle.compare("</title") == 0) { //if title is empty
+    if (iequals(cTitle, "</title")) { //if title is empty
         return false;
     }
 
 
-    while (cTitle.compare("</title") != 0) { //while searching for closing title tag
+    while (!iequals(cTitle, "</title")) { //while searching for closing title tag
 
-        if (document.substr(pos, 6).compare("</html") == 0) {
+        if (iequals(doc.substr(pos, 6), "</html")) {
             return false;
         }
         pos += 1;
-        cTitle = document.substr(pos, 7);
-        cTitle = lower(cTitle);
-        if (pos > document.size()) {
+        cTitle = doc.substr(pos, 7);
+        if (pos > doc.size()) {
             return false;
         }
     }
     pos += 7;
 
 
-    if (!properEndTag(document, pos)) {
+    if (!properEndTag(doc, pos)) {
         return false;
     }
     pos += 1;  //it now after </title>
-    advanceToNextChar(document, pos);
+    advanceToNextChar(doc, pos);
 
-    std::string closeHead(document.substr(pos, 6)); // </head
-    closeHead = lower(closeHead);
+    std::string_view closeHead = doc.substr(pos, 6); // </head
 
-    if (closeHead.compare("</head") != 0) {
+    if (!iequals(closeHead, "</head")) {
         return false;
     }
     pos += 6;
 
 
-    if (!properEndTag(document, pos)) {
+    if (!properEndTag(doc, pos)) {
         return false;
     }
 
     pos += 1; //it now right after </head>
-    advanceToNextChar(document, pos);
+    advanceToNextChar(doc, pos);
 
 
-    std::string oBody(document.substr(pos, 5));
-    oBody = lower(oBody);
+    std::string_view oBody = doc.substr(pos, 5);
 
-    if (oBody.compare("<body") != 0) {
+    if (!iequals(oBody, "<body")) {
         return false;
     }
 
 
     if (oBody.compare("<body") == 0) {   //if there is a body tag
         pos += 5;
-        advanceToNextChar(document, pos);
-        if (document.substr(pos, 2).compare("id") == 0) {
-            if (!validID(document, pos)) {
+        advanceToNextChar(doc, pos);
+        if (doc.substr(pos, 2).compare("id") == 0) {
+            if (!validID(doc, pos)) {
                 return false;
             }
         }
-        if (!properEndTag(document, pos)) {
+        if (!properEndTag(doc, pos)) {
             return false;
         }
 
 
         pos += 1;
-        std::string cBody(document.substr(pos, 6));
-        std::string cBoy(document.substr(pos, 100));
-        cBody = lower(cBody);
-        while (cBody.compare("</body") != 0) { //while searching for the closing body tag
+        std::string_view cBody = doc.substr(pos, 6);
+        while (!iequals(cBody, "</body")) { //while searching for the closing body tag
 
-            if (document.substr(pos, 2).compare("<p") == 0) { //if there's a p tag
-                if (!validPTag(document, pos)) {
+            if (iequals(doc.substr(pos, 2), "<p")) { //if there's a p tag
+                if (!validPTag(doc, pos)) {
                     return false;
                 }
-            } else if (document.substr(pos, 4).compare("<div") == 0) {  //if theres a div tag
-                if (!validDivTag(document, pos)) {
+            } else if (iequals(doc.substr(pos, 4), "<div")) {  //if theres a div tag
+                if (!validDivTag(doc, pos)) {
                     return false;
                 }
 
-            } else if (document.substr(pos, 3).compare("<br") == 0) {
-                if (!validBRTag(document, pos)) {
+            } else if (iequals(doc.substr(pos, 3), "<br")) {
+                if (!validBRTag(doc, pos)) {
                     return false;
                 }
-            } else if (document.substr(pos, 5).compare("<span") == 0) {
-                if (!validSpanTag(document, pos)) {
+            } else if (iequals(doc.substr(pos, 5), "<span")) {
+                if (!validSpanTag(doc, pos)) {
                     return false;
                 }
-            } else if (document.substr(pos, 6).compare("</html") == 0) {
+            } else if (iequals(doc.substr(pos, 6), "</html")) {
                 return false;
-            } else if (document.substr(pos, 5).compare("</div") == 0) {
+            } else if (iequals(doc.substr(pos, 5), "</div")) {
                 return false;
             }
 
             pos += 1;
-            cBody = document.substr(pos, 6);
-            cBody = lower(cBody);
-            cBoy = document.substr(pos, 100);
+            cBody = doc.substr(pos, 6);
         }
 
         pos += 6;
-        if (!properEndTag(document, pos)) {
+        if (!properEndTag(doc, pos)) {
             return false;
         }
-        if (pos == document.size() - 1) {
+        if (pos == doc.size() - 1) {
             return false;
         }
         pos += 1;  //it now right after </body>
     }
 
-    if (pos > document.size() - 5) {
+    if (pos > doc.size() - 5) {
         return false;
     }
-    advanceToNextChar(document, pos);
-    std::string cHtml(document.substr(pos, 6));
-    cHtml = lower(cHtml);
+    advanceToNextChar(doc, pos);
+    std::string_view cHtml = doc.substr(pos, 6);
 
-    if (cHtml.compare("</html") != 0) {
+    if (!iequals(cHtml, "</html")) {
         return false;
     }
 
     pos += 6;
-    if (!properEndTag(document, pos)) {
+    if (!properEndTag(doc, pos)) {
         return false;
     }
     pos += 1;
 
-    while (pos < document.size()) {
-        if (!std::isspace(static_cast<unsigned char>(document.at(pos)))) {
+    while (pos < doc.size()) {
+        if (!std::isspace(static_cast<unsigned char>(doc.at(pos)))) {
             return false;
         }
         pos += 1;
@@ -292,10 +276,14 @@ Tag *getElementByID(Tag *const root, const std::string &id) {
 
 namespace {
 
-std::string lower(std::string str) {
-    std::ranges::transform(str, str.begin(),
-                           [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-    return str;
+
+bool iequals(std::string_view a, std::string_view b) {
+    return a.size() == b.size() &&
+           std::equal(a.begin(), a.end(), b.begin(), b.end(),
+                      [](char x, char y) {
+                          return std::tolower(static_cast<unsigned char>(x)) ==
+                                 std::tolower(static_cast<unsigned char>(y));
+                      });
 }
 
 void advanceToNextChar(std::string_view str, std::size_t &pos) {
@@ -329,32 +317,27 @@ void advanceToNextChar(std::string_view str, std::size_t &pos) {
     pos += 1;                                  //need to check if there are closing tags inbetween
 
 
-    std::string cP(document.substr(pos, 3));
-    cP = lower(cP);
+    std::string_view cP = document.substr(pos, 3);
 
-    while (cP.compare("</p") != 0) { //while searching for the closing p tag
+    while (!iequals(cP, "</p")) { //while searching for the closing p tag
 
-        std::string cHtml(document.substr(pos, 6));
-        cHtml = lower(cHtml);
-        if (cHtml.compare("</html") == 0) {
+        std::string_view cHtml = document.substr(pos, 6);
+        if (iequals(cHtml, "</html")) {
             return false;
         }
-        std::string cBody(document.substr(pos, 6));
-        cBody = lower(cBody);
-        if (cBody.compare("</body") == 0) {
+        std::string_view cBody = document.substr(pos, 6);
+        if (iequals(cBody, "</body")) {
             return false;
         }
-        std::string oSPan(document.substr(pos, 5));
-        oSPan = lower(oSPan);
-        if (oSPan.compare("<span") == 0) {  //if theres a span tag in the p tag
+        std::string_view oSPan = document.substr(pos, 5);
+        if (iequals(oSPan, "<span")) {  //if theres a span tag in the p tag
             if (!validSpanTag(document, pos)) {
                 return false;
             }
 
         }
-        std::string br(document.substr(pos, 3));
-        br = lower(br);
-        if (br.compare("<br") == 0) { //if br tag inside div
+        std::string_view br = document.substr(pos, 3);
+        if (iequals(br, "<br")) { //if br tag inside div
             if (!validBRTag(document, pos)) {
                 return false;
             }
@@ -363,7 +346,6 @@ void advanceToNextChar(std::string_view str, std::size_t &pos) {
 
         pos += 1;
         cP = document.substr(pos, 3);
-        cP = lower(cP);
         if (pos > document.size()) {
             return false;
         }
@@ -392,35 +374,29 @@ void advanceToNextChar(std::string_view str, std::size_t &pos) {
         return false;
     }
     pos += 1;
-    std::string cSPan(document.substr(pos, 6));
-    cSPan = lower(cSPan);
-    while (cSPan.compare("</span") != 0) {
+    std::string_view cSPan = document.substr(pos, 6);
+    while (!iequals(cSPan, "</span")) {
 
-        std::string oP(document.substr(pos, 2));
-        oP = lower(oP);
-        if (oP.compare("<p") == 0) {
+        std::string_view oP = document.substr(pos, 2);
+        if (iequals(oP, "<p")) {
             return false;
         }
 
-        std::string oSpan(document.substr(pos, 5));
-        oSpan = lower(oSpan);
-        if (oSpan.compare("<span") == 0) {
+        std::string_view oSpan = document.substr(pos, 5);
+        if (iequals(oSpan, "<span")) {
             return false;
         }
 
-        std::string cHtml(document.substr(pos, 6));
-        cHtml = lower(cHtml);
-        if (cHtml.compare("</html") == 0) {
+        std::string_view cHtml = document.substr(pos, 6);
+        if (iequals(cHtml, "</html")) {
             return false;
         }
-        std::string cBody(document.substr(pos, 6));
-        cBody = lower(cBody);
-        if (cBody.compare("</body") == 0) {
+        std::string_view cBody = document.substr(pos, 6);
+        if (iequals(cBody, "</body")) {
             return false;
         }
-        std::string oDiv(document.substr(pos, 4));
-        oDiv = lower(oDiv);
-        if (oDiv.compare("<div") == 0) {
+        std::string_view oDiv = document.substr(pos, 4);
+        if (iequals(oDiv, "<div")) {
             return false;
         }
         if (pos > document.size()) {
@@ -428,7 +404,6 @@ void advanceToNextChar(std::string_view str, std::size_t &pos) {
         }
         pos += 1;
         cSPan = document.substr(pos, 6);
-        cSPan = lower(cSPan);
     }
     pos += 6;
 
@@ -454,38 +429,32 @@ void advanceToNextChar(std::string_view str, std::size_t &pos) {
         return false;
     }
     pos += 1;
-    std::string cDiv(document.substr(pos, 5));
-    cDiv = lower(cDiv);
-    while (cDiv.compare("</div") != 0) { //while searching for ending div tag
+    std::string_view cDiv = document.substr(pos, 5);
+    while (!iequals(cDiv, "</div")) { //while searching for ending div tag
 
-        std::string cHtml(document.substr(pos, 6));
-        cHtml = lower(cHtml);
-        if (cHtml.compare("</html") == 0) {
+        std::string_view cHtml = document.substr(pos, 6);
+        if (iequals(cHtml, "</html")) {
             return false;
         }
-        std::string cBody(document.substr(pos, 6));
-        cBody = lower(cBody);
-        if (cBody.compare("</body") == 0) {
+        std::string_view cBody = document.substr(pos, 6);
+        if (iequals(cBody, "</body")) {
             return false;
         }
 
-        std::string oP(document.substr(pos, 2));
-        oP = lower(oP);
-        if (oP.compare("<p") == 0) { //if p tag inside div
+        std::string_view oP = document.substr(pos, 2);
+        if (iequals(oP, "<p")) { //if p tag inside div
             if (!validPTag(document, pos)) {
                 return false;
             }
         }
-        std::string oSPan(document.substr(pos, 5));
-        oSPan = lower(oSPan);
-        if (oSPan.compare("<span") == 0) { //if span tag inside div
+        std::string_view oSPan = document.substr(pos, 5);
+        if (iequals(oSPan, "<span")) { //if span tag inside div
             if (!validSpanTag(document, pos)) {
                 return false;
             }
         }
-        std::string br(document.substr(pos, 3));
-        br = lower(br);
-        if (br.compare("<br") == 0) { //if br tag inside div
+        std::string_view br = document.substr(pos, 3);
+        if (iequals(br, "<br")) { //if br tag inside div
             if (!validBRTag(document, pos)) {
                 return false;
             }
@@ -493,9 +462,8 @@ void advanceToNextChar(std::string_view str, std::size_t &pos) {
         }
 
 
-        std::string oDiv(document.substr(pos, 4));
-        oDiv = lower(oDiv);
-        if (oDiv.compare("<div") == 0) {
+        std::string_view oDiv = document.substr(pos, 4);
+        if (iequals(oDiv, "<div")) {
             if (!validDivTag(document, pos)) {
                 return false;
             }
@@ -503,7 +471,6 @@ void advanceToNextChar(std::string_view str, std::size_t &pos) {
 
         pos += 1;
         cDiv = document.substr(pos, 5);
-        cDiv = lower(cDiv);
     }
     pos += 5;
     if (!properEndTag(document, pos)) {

--- a/HTMLValidator.cpp
+++ b/HTMLValidator.cpp
@@ -171,7 +171,7 @@ void advanceToNextChar(std::string_view str, std::size_t &pos);
     }
 
 
-    if (oBody.compare("<body") == 0) {   //if there is a body tag
+    if (iequals(oBody, "<body")) {   //if there is a body tag
         pos += 5;
         advanceToNextChar(doc, pos);
         if (doc.substr(pos, 2).compare("id") == 0) {


### PR DESCRIPTION
## Summary
- improve speed by avoiding string copies
- add case-insensitive `iequals` helper
- replace repeated `lower` calls with `iequals`
- use `std::string_view` for lightweight substrings

## Testing
- `bash test_sample_pages.sh`


------
https://chatgpt.com/codex/tasks/task_e_683faab05288832ca48c1be50987d00e